### PR TITLE
Remove test console output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
         "ecmaVersion": 12
     },
     "rules": {
+      "no-console": "error"
     }
 };

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ function avif(options) {
                 return metadata;
             })
             .then((metadata) => {
-                console.log('test' + metadata.format);
                 let img = source;
                 if (metadata.format === 'svg' && options && (options.width || options.height)) {
                     img = source.resize(options.width, options.height);


### PR DESCRIPTION
Hi!
Thanks for the package! It's really handy ^_^

I noticed the console output with the `test` string in the callback. It logs the metadata when performing the task, so the console might get a bit messy if there are many images:

<img width="295" alt="«Screenshot» 2022-05-15 at 22 42 15" src="https://user-images.githubusercontent.com/9102374/168493021-08ac1cae-da88-4aa3-907f-3af6b38c8abb.png">

I don't know if that was intentional but this PR removes the `console.log` from the callback. If that _was_ intentional, feel free to just close this PR :–)

If not, I've also set up a linter rule for errors on unexpected console logs 🙌 